### PR TITLE
38-display-transcript-details

### DIFF
--- a/app/api/post/[postId]/route.ts
+++ b/app/api/post/[postId]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { postSelectContent } from "@/lib/helper"
+import { prisma } from "@/lib/prisma"
+
+type paramsProps = { params: { postId: string } }
+
+export async function GET(request: NextRequest, { params }: paramsProps) {
+  const { postId } = params
+  const getPost = await prisma.post.findFirst({
+    where: {
+      id: Number(postId),
+    },
+    select: postSelectContent,
+  })
+  // console.log(getPost)
+  return NextResponse.json(getPost)
+}

--- a/app/api/post/route.ts
+++ b/app/api/post/route.ts
@@ -3,26 +3,6 @@ import { NextResponse, type NextRequest } from "next/server"
 
 import { prisma } from "@/lib/prisma"
 
-export async function GET() {
-  const getAllPosts = await prisma.post.findMany({
-    select: {
-      id: true,
-      originalVideoLink: true,
-      sessionName: true,
-      leaderName: true,
-      duration: true,
-      viewsNum: true,
-      votesNum: true,
-      syllabus: { select: { name: true } },
-      cohort: { select: { name: true } },
-      user: { select: { name: true } },
-      transcription: { select: { sentences: { select: { content: true } } } },
-    },
-  })
-  revalidatePath("/")
-  return NextResponse.json(getAllPosts)
-}
-
 export async function POST(request: NextRequest) {
   const body: createPostFromClientType = await request.json()
   const {

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -1,0 +1,13 @@
+import { revalidatePath } from "next/cache"
+import { NextResponse, type NextRequest } from "next/server"
+
+import { postSelectContent } from "@/lib/helper"
+import { prisma } from "@/lib/prisma"
+
+export async function GET() {
+  const getAllPosts = await prisma.post.findMany({
+    select: postSelectContent,
+  })
+  revalidatePath("/")
+  return NextResponse.json(getAllPosts)
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,11 +1,11 @@
 import Image from "next/image"
-import Link from "next/link"
 
 import getAllPosts from "@/lib/getAllPosts"
+import DashboardTableTr from "@/components/dashboard/TableTr"
 import UserSession from "@/components/dashboard/UserSession"
 
 export default async function Dashboard() {
-  const postsData = getAllPosts()
+  const postsData: Promise<PostType[]> = getAllPosts()
   const posts = await postsData
 
   return (
@@ -18,8 +18,8 @@ export default async function Dashboard() {
         <Image
           src="/images/img2.jpg"
           alt="image related to cyf"
-          width={350}
-          height={350}
+          width={200}
+          height={200}
           className="rounded"
         />
       </div>
@@ -27,27 +27,21 @@ export default async function Dashboard() {
         <h2 className="text-2xl font-bold text-center mt-8 mb-4 text-red-500">
           List of transcripts
         </h2>
-        <table className="w-full border-collapse">
+
+        <table className="w-full border-collapse text-center">
           <thead>
             <tr>
-              <th className="py-2 px-4 border">Cohort name</th>
-              <th className="py-2 px-4 border">Syllabus module name</th>
-              <th className="py-2 px-4 border">Session name</th>
-              <th className="py-2 px-4 border">Leader name</th>
-              <th className="py-2 px-4 border">Number of Views</th>
+              <th className="py-2 px-4 border">Cohort</th>
+              <th className="py-2 px-4 border">Syllabus</th>
+              <th className="py-2 px-4 border">Session</th>
+              <th className="py-2 px-4 border">Leader</th>
+              <th className="py-2 px-4 border">Views</th>
               <th className="py-2 px-4 border">Votes</th>
             </tr>
           </thead>
           <tbody>
-            {posts.map((post: any) => (
-              <tr key={post.id}>
-                <td className="py-2 px-4 border">{post.cohort.name}</td>
-                <td className="py-2 px-4 border">{post.syllabus.name}</td>
-                <td className="py-2 px-4 border">{post.sessionName}</td>
-                <td className="py-2 px-4 border">{post.leaderName}</td>
-                <td className="py-2 px-4 border">{post.viewsNum}</td>
-                <td className="py-2 px-4 border">{post.votesNum}</td>
-              </tr>
+            {posts.map((post) => (
+              <DashboardTableTr post={post} />
             ))}
           </tbody>
         </table>

--- a/app/dashboard/posts/[postId]/page.tsx
+++ b/app/dashboard/posts/[postId]/page.tsx
@@ -1,0 +1,86 @@
+import React from "react"
+import Link from "next/link"
+import { ThickArrowUpIcon } from "@radix-ui/react-icons"
+
+import getPost from "@/lib/getPost"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+type TranscriptDetailsProps = {
+  params: { postId: string }
+}
+export default async function TranscriptDetails({
+  params: { postId },
+}: TranscriptDetailsProps) {
+  const postData: Promise<PostType> = getPost(postId)
+  const post = await postData
+  const {
+    cohort,
+    syllabus,
+    sessionName,
+    leaderName,
+    originalVideoLink,
+    duration,
+    viewsNum,
+    votesNum,
+    user,
+    transcription,
+  } = post
+  const article = transcription.sentences
+    .map((sentence: { content: string }) => sentence.content)
+    .join(" ")
+  return (
+    <>
+      <div className="flex justify-center gap-4">
+        <Button asChild variant="destructive">
+          <Link href="/dashboard">Back to the dashboard</Link>
+        </Button>
+        <Button asChild>
+          <Link href="">Edit</Link>
+        </Button>
+        <Button asChild>
+          <Link href="">Delete</Link>
+        </Button>
+        <Button>
+          <ThickArrowUpIcon className="mr-2 h-4 w-4" />
+          vote
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <p>
+              {cohort.name} {syllabus.name}
+            </p>
+            <p>
+              {sessionName} by {leaderName}
+            </p>
+          </CardTitle>
+          <CardDescription>
+            {originalVideoLink && <p>Video: {originalVideoLink}</p>}
+            <p className="flex justify-start gap-2">
+              <Badge>duration: {duration}min(s)</Badge>
+              <Badge>views: {viewsNum}</Badge> <Badge>votes: {votesNum}</Badge>
+            </p>
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <b>Transcription:</b>
+          <p className="select-none">{article}</p>
+        </CardContent>
+        <CardFooter>
+          <p>Uploader: {user.name}</p>
+        </CardFooter>
+      </Card>
+    </>
+  )
+}

--- a/components/dashboard/TableTr.tsx
+++ b/components/dashboard/TableTr.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import React from "react"
+import { useRouter } from "next/navigation"
+
+export default function DashboardTableTr({ post }: DashboardTableTrPropsType) {
+  const router = useRouter()
+  return (
+    <tr
+      key={post.id}
+      onClick={() => router.push(`/dashboard/posts/${post.id}`)}
+      className="cursor-pointer hover:bg-gray-50"
+    >
+      <td className="py-2 px-4 border ">{post.cohort.name}</td>
+      <td className="py-2 px-4 border">{post.syllabus.name}</td>
+      <td className="py-2 px-4 border">{post.sessionName}</td>
+      <td className="py-2 px-4 border">{post.leaderName}</td>
+      <td className="py-2 px-4 border">{post.viewsNum}</td>
+      <td className="py-2 px-4 border">{post.votesNum}</td>
+    </tr>
+  )
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/lib/getAllPosts.ts
+++ b/lib/getAllPosts.ts
@@ -2,7 +2,7 @@ export default async function getAllPosts() {
   // const res = await fetch(`${process.env.NEXTAUTH_URL}/api/post`, {
   //   cache: "no-store",
   // })
-  const res = await fetch(`${process.env.NEXTAUTH_URL}/api/post`)
+  const res = await fetch(`${process.env.NEXTAUTH_URL}/api/posts`)
   if (!res.ok) throw new Error("failed to fetch data")
   return res.json()
 }

--- a/lib/getPost.ts
+++ b/lib/getPost.ts
@@ -1,0 +1,5 @@
+export default async function getPost(postId: string) {
+  const res = await fetch(`${process.env.NEXTAUTH_URL}/api/post/${postId}`)
+  if (!res.ok) throw new Error("failed to fetch data")
+  return res.json()
+}

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -1,0 +1,15 @@
+//---api---
+//post select content in Prisma
+export const postSelectContent = {
+  id: true,
+  originalVideoLink: true,
+  sessionName: true,
+  leaderName: true,
+  duration: true,
+  viewsNum: true,
+  votesNum: true,
+  syllabus: { select: { name: true } },
+  cohort: { select: { name: true } },
+  user: { select: { name: true } },
+  transcription: { select: { sentences: { select: { content: true } } } },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-popover": "^1.0.6",
         "@radix-ui/react-scroll-area": "^1.0.4",
+        "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.4",
@@ -1405,6 +1406,29 @@
         "@radix-ui/react-primitive": "1.0.3",
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.0.3.tgz",
+      "integrity": "sha512-itYmTy/kokS21aiV5+Z56MZB54KrhPgn6eHDKkFeOLR34HMN2s8PaN47qZZAGnvupcjxHaFZnW4pQEh0BvvVuw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-scroll-area": "^1.0.4",
+    "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.4",

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -4,7 +4,6 @@ type createSentenceType = {
   endTime: string
   content: string
 }
-type transcriptionType = createSentenceType[]
 
 type createTranscriptionType = {
   sentences: createSentenceType[]
@@ -14,7 +13,7 @@ type commonFields = {
   sessionName: string
   leaderName: string
   originalVideoLink?: string
-  transcription: transcriptionType
+  transcription: createSentenceType[]
 }
 
 type createPostType = commonFields & {
@@ -26,4 +25,30 @@ type createPostFromClientType = commonFields & {
   cohortName: string
   syllabusName: string
   user: { id: string }
+}
+type PostType = {
+  id: number
+  originalVideoLink?: string
+  sessionName: string
+  leaderName: string
+  duration: number
+  viewsNum: number
+  votesNum: number
+  syllabus: {
+    name: string
+  }
+  cohort: {
+    name: string
+  }
+  user: {
+    name: string
+  }
+  transcription: {
+    sentences: {
+      content: string
+    }[]
+  }
+}
+type DashboardTableTrPropsType = {
+  post: PostType
 }


### PR DESCRIPTION
This is a:

<!-- Tick one category - if more than one applies, it should be split up -->

- [x] ✨ **New feature** - new behaviour has been implemented
- [ ] 🐛 **Bug fix** - existing behaviour has been made to behave
- [ ] ♻️ **Refactor** - the behaviour has not changed, just the implementation
- [ ] ⚙️ **Chore** - maintenance task, behaviour and implementation haven't changed

<!-- adapted from https://gitmoji.dev/ -->

### Description

<!-- Describe what merging this pull request will do -->

- **Purpose** - 
Users should be able to click on a transcript from the Browse page and it should open a detailed view of the transcript. All fields should be displayed.
If the user is the one that initially uploaded the transcript, should be able to edit the details (Edit is another Issue https://github.com/susanssky/careless-whisper/issues/39). This should be a separate "Edit" button on the page.

<!-- Describe how the reviewer should check it works -->

- **How to check** - 
1. `npx prisma migrate dev --name init`
2. after login with github
3. go http://localhost:3000/dashboard/create-post to upload the srt file
4. (If you can, you can submit some posts)
5. go http://localhost:3000/dashboard/ to see the list and click the different row to read the posts/transcrption


### Links
- Story: #38
<!-- links to other issues/PRs/tickets, e.g. user/repo#123 -->

### Author checklist

<!-- All PRs -->

- [X] I have written a title that reflects the relevant ticket
- [X] I have written a description that says what the PR does and how to validate it
- [X] I have linked to the project board ticket (and any related PRs/issues) in the Links section
- [X] I have added a link to this PR to the ticket
- [ ] I have requested reviewers here and in my team chat channel
<!-- if new endpoints were introduced -->
- [ ] I have explicitly tested the access rights for _at least_ unauthenticated and admin cases
