### PR TITLE
12-vote-transcription-fe-be

### DIFF
--- a/app/(backend)/api/post/[postId]/route.ts
+++ b/app/(backend)/api/post/[postId]/route.ts
@@ -25,8 +25,26 @@ export async function GET(request: NextRequest, { params }: paramsProps) {
   return NextResponse.json(getPost)
 }
 
+
+
 export async function DELETE(request: NextRequest, { params }: paramsProps) {
   const { postId } = params
+
+  const votesForPost = await prisma.vote.findMany({
+    where: {
+      postId: parseInt(postId),
+    },
+  })
+
+  if (votesForPost.length > 0) {
+    await prisma.vote.deleteMany({
+      where: {
+        postId: parseInt(postId),
+      },
+    })
+  }
+
+
   const deletedPost = await prisma.post.delete({
     where: {
       id: Number(postId),
@@ -35,6 +53,7 @@ export async function DELETE(request: NextRequest, { params }: paramsProps) {
 
   return NextResponse.json(deletedPost)
 }
+
 
 export async function POST(request: NextRequest, { params }: paramsProps) {
   try {

--- a/app/(backend)/api/vote/route.ts
+++ b/app/(backend)/api/vote/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { prisma } from "@/lib/prisma"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const postId = searchParams.get("postId")
+    const userId = searchParams.get("userId")
+
+    if (!postId || !userId) {
+      return new Response("Post ID or User ID is missing", { status: 400 })
+    }
+
+    const vote = await prisma.vote.create({
+      data: {
+        postId: parseInt(postId),
+        userId: userId,
+      },
+    })
+
+    const updatedPost = await prisma.post.update({
+      where: {
+        id: parseInt(postId),
+      },
+      data: {
+        votesNum: {
+          increment: 1,
+        },
+      },
+    })
+
+    return NextResponse.json(updatedPost)
+  } catch (error: any) {
+    console.error("Error voting for post:", error)
+    return new Response(error.message, { status: 500 })
+  }
+}

--- a/components/post/PostComponent.tsx
+++ b/components/post/PostComponent.tsx
@@ -1,26 +1,22 @@
-"use client"
+"use client";
 
-import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { ThickArrowUpIcon } from "@radix-ui/react-icons"
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ThickArrowUpIcon } from "@radix-ui/react-icons";
 
-import { deletePost } from "@/lib/deletePost"
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+
+
+import { deletePost } from "@/lib/deletePost";
+import { voteTranscription } from "@/lib/voteTranscription";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+
+
+
 
 type PostComponentProps = {
   post: PostType
@@ -28,6 +24,10 @@ type PostComponentProps = {
 }
 export default function PostComponent({ post, session }: PostComponentProps) {
   const router = useRouter()
+
+
+
+
   const {
     id,
     cohort,
@@ -47,6 +47,39 @@ export default function PostComponent({ post, session }: PostComponentProps) {
   const article = transcription.sentences
     .map((sentence: { content: string }) => sentence.content)
     .join(" ")
+
+  const [voted, setVoted] = useState(() => {
+    const hasVoted = localStorage.getItem(`voted_${id}_${session.user.id}`);
+    return hasVoted ? true : false;
+  });
+
+  const [error, setError] = useState("");
+
+
+const handleVote = async () => {
+  if (!voted) {
+    try {
+      const updatedPost = await voteTranscription(id, session.user.id)
+      if (updatedPost) {
+        setVoted(true)
+        localStorage.setItem(`voted_${id}_${session.user.id}`, "true")
+      
+        alert("Thank you for voting!")
+        setError("")
+      } else {
+        setError("Failed to vote. Please try again.")
+      }
+    } catch (error) {
+      console.error("Failed to vote:", error)
+      setError("Failed to vote. Please try again.")
+    }
+  } else {
+  
+    alert("You have already voted. Thank you for your participation!")
+  }
+}
+
+
   const handleDelete = async (postId: number) => {
     const success = await deletePost(postId.toString())
 
@@ -77,10 +110,11 @@ export default function PostComponent({ post, session }: PostComponentProps) {
           </>
         )}
 
-        <Button>
-          <ThickArrowUpIcon className="mr-2 h-4 w-4" />
-          vote
-        </Button>
+         <Button onClick={handleVote} disabled={voted}>
+  <ThickArrowUpIcon className="mr-2 h-4 w-4" />
+  {voted ? "Voted" : "Vote"}
+</Button>
+
       </div>
       <Card>
         <CardHeader>

--- a/lib/voteTranscription.ts
+++ b/lib/voteTranscription.ts
@@ -1,0 +1,30 @@
+interface Post {
+  id: number
+  votesNum: number | null
+}
+export async function voteTranscription(
+  postId: number,
+  userId: string
+): Promise<Post | null> {
+  try {
+    const response = await fetch(
+      `/api/vote?postId=${postId}&userId=${userId}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    )
+
+    if (response.ok) {
+      const updatedPost = await response.json()
+      return updatedPost as Post
+    } else {
+      throw new Error("Failed to vote")
+    }
+  } catch (error) {
+    console.error("Failed to vote:", error)
+    return null
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,7 @@ model Post {
     cohortId          Int
     transcription     Transcription?
     summary           String?
+     votes            Vote[]
 }
 
 model Cohort {
@@ -124,3 +125,14 @@ model SearchQuery {
     query     String
     createdAt DateTime @default(now())
 }
+
+model Vote{
+     id        Int      @id @default(autoincrement())
+     userId String
+     post     Post @relation(fields: [postId], references: [id])
+     postId Int
+     createdAt DateTime @default(now())
+     @@unique([userId,postId])
+
+}
+


### PR DESCRIPTION
- [x] ✨ **New feature** - new behaviour has been implemented
- [x] 🐛 **Bug fix** - existing behaviour has been made to behave
- [ ] ♻️ **Refactor** - the behaviour has not changed, just the implementation
- [ ] ⚙️ **Chore** - maintenance task, behaviour and implementation haven't changed

### Description

#### Purpose:

This PR adds the voting feature, allowing users to vote on post transcriptions and making sure that each user can vote only once for each transcription. Changes include backend API updates to handle voting requests, the addition of the Prisma Vote model to store voting data, and frontend modifications to manage voting logic and display relevant alerts. The feature empowers users to appreciate valuable transcriptions.

- Also I have done some updates related to the delete tasks , so voted transcription can also be deleted


- **Testing** - 

- `npx prisma migrate dev --name init`
- `npm run dev`
-  login with github
- click on any post in the list, click vote ,  make sure the button will be deactivated and changes to `voted` after you 
  voted once, as every user should be able to vote only one time.
- You might need to refresh the page to see the result on the table and other related parts in dashboard. 


### Author Checklist

- [x]  have written a title that reflects the relevant ticket
- [x] I have written a description that says what the PR does and how to validate it
- [x]  I have linked to the project board ticket (and any related PRs/issues) in the Links section
- [x] I have added a link to this PR to the ticket
- [ ]  I have requested reviewers here and in my team chat channel
